### PR TITLE
Centralize sidebar via AppShell and exclude landing

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,5 +1,4 @@
 import { Header } from "@/components/header"
-import { Sidebar } from "@/components/sidebar"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -46,11 +45,9 @@ const statusColors = {
 
 export default function Dashboard() {
   return (
-    <div className="flex h-screen bg-background">
-      <Sidebar />
-      <div className="flex-1 flex flex-col">
-        <Header />
-        <main className="flex-1 p-6 space-y-6">
+    <>
+      <Header />
+      <div className="space-y-6">
           <div>
             <h1 className="text-3xl font-bold text-balance">Welcome back, Birat</h1>
             <p className="text-muted-foreground text-pretty">Here's what's happening with your pull requests today.</p>
@@ -131,8 +128,7 @@ export default function Dashboard() {
               </div>
             </CardContent>
           </Card>
-        </main>
       </div>
-    </div>
+    </>
   )
 }

--- a/frontend/app/generate/page.tsx
+++ b/frontend/app/generate/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { Header } from "@/components/header"
-import { Sidebar } from "@/components/sidebar"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -126,11 +125,9 @@ Fully backward compatible - no breaking changes.`)
   }
 
   return (
-    <div className="flex h-screen bg-background">
-      <Sidebar />
-      <div className="flex-1 flex flex-col">
-        <Header />
-        <main className="flex-1 p-6 space-y-6">
+    <>
+      <Header />
+      <main className="p-6 space-y-6">
           <div>
             <h1 className="text-3xl font-bold text-balance">Generate Pull Request</h1>
             <p className="text-muted-foreground text-pretty">
@@ -332,8 +329,7 @@ Fully backward compatible - no breaking changes.`)
               </div>
             </CardContent>
           </Card>
-        </main>
-      </div>
-    </div>
+      </main>
+    </>
   )
 }

--- a/frontend/app/insights/page.tsx
+++ b/frontend/app/insights/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { Header } from "@/components/header"
-import { Sidebar } from "@/components/sidebar"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { BarChart, Bar, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts"
@@ -45,11 +44,9 @@ export default function RepoInsights() {
   const [timeRange, setTimeRange] = useState("30d")
 
   return (
-    <div className="flex h-screen bg-background">
-      <Sidebar />
-      <div className="flex-1 flex flex-col">
-        <Header />
-        <main className="flex-1 p-6 space-y-6">
+    <>
+      <Header />
+      <main className="p-6 space-y-6">
           <div className="flex items-center justify-between">
             <div>
               <h1 className="text-3xl font-bold text-balance">Repository Insights</h1>
@@ -248,8 +245,7 @@ export default function RepoInsights() {
               </div>
             </CardContent>
           </Card>
-        </main>
-      </div>
-    </div>
+      </main>
+    </>
   )
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,11 +1,7 @@
-import type React from "react"
 import type { Metadata } from "next"
-import { GeistSans } from "geist/font/sans"
-import { GeistMono } from "geist/font/mono"
-import { Analytics } from "@vercel/analytics/next"
-import { Suspense } from "react"
-import { ThemeProvider } from "@/components/theme-provider"
 import "./globals.css"
+import { AppShell } from "@/components/app-shell"
+
 
 export const metadata: Metadata = {
   title: "PullPal - AI-Powered Pull Request Assistant",
@@ -13,18 +9,11 @@ export const metadata: Metadata = {
   generator: "v0.app",
 }
 
-export default function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode
-}>) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable}`}>
-        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
-          <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
-          <Analytics />
-        </ThemeProvider>
+    <html lang="en" className="dark">
+      <body className="font-sans">
+        <AppShell>{children}</AppShell>
       </body>
     </html>
   )

--- a/frontend/app/review/page.tsx
+++ b/frontend/app/review/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { Header } from "@/components/header"
-import { Sidebar } from "@/components/sidebar"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
@@ -184,11 +183,9 @@ export default function ReviewPR() {
   const selectedStyle = reviewStyles.find((s) => s.id === reviewStyle)
 
   return (
-    <div className="flex h-screen bg-background">
-      <Sidebar />
-      <div className="flex-1 flex flex-col">
-        <Header />
-        <main className="flex-1 p-6 space-y-6">
+    <>
+      <Header />
+      <main className="p-6 space-y-6">
           <div>
             <h1 className="text-3xl font-bold text-balance">Review Pull Request</h1>
             <p className="text-muted-foreground text-pretty">
@@ -341,8 +338,7 @@ export default function ReviewPR() {
               </Card>
             </div>
           )}
-        </main>
-      </div>
-    </div>
+      </main>
+    </>
   )
 }

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { Header } from "@/components/header"
-import { Sidebar } from "@/components/sidebar"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -79,11 +78,9 @@ export default function Settings() {
   }
 
   return (
-    <div className="flex h-screen bg-background">
-      <Sidebar />
-      <div className="flex-1 flex flex-col">
-        <Header />
-        <main className="flex-1 p-6 space-y-6">
+    <>
+      <Header />
+      <main className="p-6 space-y-6">
           <div>
             <h1 className="text-3xl font-bold text-balance">Settings</h1>
             <p className="text-muted-foreground text-pretty">
@@ -324,8 +321,7 @@ export default function Settings() {
               </div>
             </CardContent>
           </Card>
-        </main>
-      </div>
-    </div>
+      </main>
+    </>
   )
 }

--- a/frontend/components/app-shell.tsx
+++ b/frontend/components/app-shell.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { usePathname } from "next/navigation"
+import { Sidebar } from "@/components/sidebar"
+
+export function AppShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const showSidebar = !pathname.startsWith("/landing")
+
+  if (!showSidebar) {
+    return <main className="min-h-screen">{children}</main>
+  }
+
+  return (
+    <div className="flex h-screen">
+      <Sidebar />
+      <main className="flex-1 p-6 overflow-auto">{children}</main>
+    </div>
+  )
+}
+
+

--- a/frontend/components/sidebar.tsx
+++ b/frontend/components/sidebar.tsx
@@ -3,12 +3,12 @@
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
-import { LayoutDashboard, GitPullRequest, FileSearch, BarChart3, Settings, Code2 } from "lucide-react"
+import { LayoutDashboard, GitPullRequest, FileSearch, BarChart3, Settings, Code2, FolderGit2 } from "lucide-react"
 
 const navigation = [
   {
     name: "Dashboard",
-    href: "/",
+    href: "/dashboard",
     icon: LayoutDashboard,
   },
   {
@@ -20,6 +20,11 @@ const navigation = [
     name: "Review PR",
     href: "/review",
     icon: FileSearch,
+  },
+  {
+    name: "Repos",
+    href: "/repos",
+    icon: FolderGit2,
   },
   {
     name: "Repo Insights",
@@ -67,3 +72,5 @@ export function Sidebar() {
     </div>
   )
 }
+
+ 


### PR DESCRIPTION
This PR introduces a unified layout that renders the global sidebar across the app while keeping the landing page clean.
Centralizes sidebar rendering using AppShell and root app/layout.tsx
Excludes sidebar on routes under /landing
Adds “Repos” to the sidebar navigation
Resolves Sidebar file casing/import issues
Aligns Dashboard entry to /dashboard
Removes duplicated sidebar wrappers from individual pages